### PR TITLE
Fix Plugin for use out on Phaser v.3.50.0

### DIFF
--- a/src/plugin/main.js
+++ b/src/plugin/main.js
@@ -180,8 +180,7 @@ class AnimatedTiles extends Phaser.Plugins.ScenePlugin {
                         if (animatedTile.next < 0) {
                             // Remember current frame index
                             let currentIndex = animatedTile.currentFrame;
-                            // Remember the tileId of current tile
-                            let oldTileId = animatedTile.frames[currentIndex].tileid;
+                           
                             // Advance to next in line
                             let newIndex = currentIndex + 1;
                             // If we went beyond last frame, we just start over
@@ -199,7 +198,7 @@ class AnimatedTiles extends Phaser.Plugins.ScenePlugin {
                                 if (!mapAnimData.activeLayer[layerIndex]) {
                                     return;
                                 }
-                                this.updateLayer(animatedTile, layer, oldTileId);
+                                this.updateLayer(animatedTile, layer);
 
                             });
                         }


### PR DESCRIPTION
I tested this on Phaser v.3.50.0 out of the box and it threw an error on the previous line 184:

`let oldTileId = animatedTile.frames[currentIndex].tileid;`

I think the main reason is that `currentIndex` will not always have a corresponding tileid. 

Regardless, the value is set directly below:

`updateLayer(animatedTile, layer, oldTileId = -1)`

with oldTileId simply being set to -1 as it's passed, so removing the previous line allows the plugin to work properly.

Here's a working video example:

https://youtu.be/7uUPjIzGOWM